### PR TITLE
Fix OSX non-homebrew python install: Added vars to makefile for setting dirs from command-line.

### DIFF
--- a/makefile.OSX
+++ b/makefile.OSX
@@ -15,6 +15,11 @@ BUILDDIR := build
 OBJECTS := $(patsubst $(SRCDIR)/%,$(BUILDDIR)/%,$(SOURCES:.$(SRCEXT)=.o))
 
 CPP_DEPS = $(OBJECTS:.o=.d)
+	
+# Change these to set the different python directories
+PYTHONHEADERDIR = /usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Headers/
+PYTHONLIBDIR = /usr/local/lib/python2.7
+PYTHONFRAMEWORKDIR = /usr/local/Library/Frameworks
 
 LIBS := -framework Python -framework OpenGL -framework GLUT -framework OpenCL
 
@@ -26,7 +31,7 @@ all: Smoothed-Particle-Hydrodynamics
 Smoothed-Particle-Hydrodynamics: $(OBJECTS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: clang C++ Linker'
-	g++ -L/usr/lib -L/usr/local/lib/python2.7 -o $(BUILDDIR)/Smoothed-Particle-Hydrodynamics $(OBJECTS) $(LIBS)
+	g++ -L/usr/lib -F$(PYTHONFRAMEWORKDIR) -L$(PYTHONLIBDIR) -o $(BUILDDIR)/Smoothed-Particle-Hydrodynamics $(OBJECTS) $(LIBS)
 	@echo 'Finished building target: $@'
 	@echo ' '
 
@@ -36,7 +41,7 @@ $(BUILDDIR)/%.o: $(SRCDIR)/%.cpp
 	@echo 'Invoking: clang C++ Compiler'
 #### use this to compile against homebrew installed python
 #### change version number as necessary (2.7.n)
-	g++ -O1 -Wall -c -I/usr/local/Cellar/python/2.7.6/Frameworks/Python.framework/Headers/ -framework OpenCL -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"
+	g++ -O1 -Wall -c -I$(PYTHONHEADERDIR) -framework OpenCL -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' '
 


### PR DESCRIPTION
In response to #26, I have made a partial fix to the OSX makefile, by allowing the user to specify python location on the commandline using three new variables: PYTHONLIBDIR, PYTHONHEADERDIR, and PYTHONFRAMEWORKDIR.
