### PR TITLE
Missing build line for owNeuronSimulator.cpp in the OS X makefile.

### DIFF
--- a/makefile.OSX
+++ b/makefile.OSX
@@ -8,7 +8,8 @@ src/main.cpp \
 src/owHelper.cpp \
 src/owOpenCLSolver.cpp \
 src/owPhysicsFluidSimulator.cpp \
-src/owWorldSimulation.cpp
+src/owWorldSimulation.cpp \
+src/owNeuronSimulator.cpp
 
 TEST_SOURCES = src/test/owPhysicTest.cpp
 


### PR DESCRIPTION
The code will not build on the Mac otherwise.