### PR TITLE
Windows compatibility edits

### DIFF
--- a/inc/gettimeofday.h
+++ b/inc/gettimeofday.h
@@ -1,0 +1,59 @@
+#ifndef FUNCTIONS_H_INCLUDED
+#define FUNCTIONS_H_INCLUDED
+
+#include < time.h >
+#include < winsock2.h >
+#include <windows.h> //I've ommited this line.
+#if defined(_MSC_VER) || defined(_MSC_EXTENSIONS)
+  #define DELTA_EPOCH_IN_MICROSECS  11644473600000000Ui64
+#else
+  #define DELTA_EPOCH_IN_MICROSECS  11644473600000000ULL
+#endif
+ 
+struct timezone 
+{
+  int  tz_minuteswest; /* minutes W of Greenwich */
+  int  tz_dsttime;     /* type of dst correction */
+};
+
+//struct timeval 
+//{
+//    long    tv_sec;
+//    long    tv_usec;
+//};
+ 
+int gettimeofday(struct timeval *tv, struct timezone *tz)
+{
+  FILETIME ft;
+  unsigned __int64 tmpres = 0;
+  static int tzflag;
+ 
+  if (NULL != tv)
+  {
+    GetSystemTimeAsFileTime(&ft);
+ 
+    tmpres |= ft.dwHighDateTime;
+    tmpres <<= 32;
+    tmpres |= ft.dwLowDateTime;
+ 
+    /*converting file time to unix epoch*/
+    tmpres -= DELTA_EPOCH_IN_MICROSECS; 
+    tmpres /= 10;  /*convert into microseconds*/
+    tv->tv_sec = (long)(tmpres / 1000000UL);
+    tv->tv_usec = (long)(tmpres % 1000000UL);
+  }
+ 
+  if (NULL != tz)
+  {
+    if (!tzflag)
+    {
+      _tzset();
+      tzflag++;
+    }
+    tz->tz_minuteswest = _timezone / 60;
+    tz->tz_dsttime = _daylight;
+  }
+ 
+  return 0;
+}
+#endif

--- a/inc/owNeuronSimulator.h
+++ b/inc/owNeuronSimulator.h
@@ -43,7 +43,7 @@
 #define INC_OWNEURONSIMULATOR_H_
 
 #if defined(_WIN32) || defined (_WIN64)
-  #include "C:/Python27/include/Python.h" // TODO make it optional
+  #include "Python.h" // TODO make it optional
 #else
   #include <Python.h>
 #endif

--- a/inc/owPhysicsFluidSimulator.h
+++ b/inc/owPhysicsFluidSimulator.h
@@ -34,6 +34,10 @@
 #ifndef OW_PHYSICS_SIMULATOR_H
 #define OW_PHYSICS_SIMULATOR_H
 
+#if defined(_WIN32) || defined (_WIN64)
+	#include < WinSock2.h>
+#endif
+
 #include <time.h>
 
 #include "owPhysicsConstant.h"

--- a/inc/owSignalSimulator.h
+++ b/inc/owSignalSimulator.h
@@ -36,7 +36,7 @@
 //#include "/usr/include/python2.7/Python.h"  //need to fix
 //#define MS_NO_COREDLL
 #if defined(_WIN32) || defined (_WIN64)
-  #include "C:/Python27/include/Python.h" // TODO make it optional
+  #include "Python.h" // TODO make it optional
 #else
   #include <Python.h>
 #endif

--- a/src/owHelper.cpp
+++ b/src/owHelper.cpp
@@ -590,7 +590,7 @@ bool owHelper::loadConfigurationFromFile(float *&position, float *&connections,
     positionFile.open(positionFileName.c_str());
   }
   unsigned int i = 0;
-  float x, y, z, p_type;
+  float x, y, z, p_type=0;
   if (positionFile.is_open()) {
     if (iteration == 0) {
       float valueF;

--- a/src/owPhysicsFluidSimulator.cpp
+++ b/src/owPhysicsFluidSimulator.cpp
@@ -36,6 +36,11 @@
 #include <stdexcept>
 #include <iomanip>>
 
+#if defined(_WIN32) || defined (_WIN64)
+    #include "gettimeofday.h"
+    #include < WinSock2.h>
+#endif
+
 #include "owPhysicsFluidSimulator.h"
 #include "owSignalSimulator.h"
 #include "owVtkExport.h"

--- a/src/owSignalSimulator.cpp
+++ b/src/owSignalSimulator.cpp
@@ -60,7 +60,7 @@ SignalSimulator::SignalSimulator(const std::string &simFileName,
   pName = PyUnicode_FromString(simFileName.c_str());
   PyObject * temp_bytes = PyUnicode_AsEncodedString(pName, "UTF-8", "strict");
   const char * s = PyBytes_AS_STRING(temp_bytes);
-  s = _strdup(s);
+  s = strdup(s);
   Py_DECREF(temp_bytes);
 
   printf("[debug] pName = \"%s\"\n", s);

--- a/src/owSignalSimulator.cpp
+++ b/src/owSignalSimulator.cpp
@@ -60,7 +60,7 @@ SignalSimulator::SignalSimulator(const std::string &simFileName,
   pName = PyUnicode_FromString(simFileName.c_str());
   PyObject * temp_bytes = PyUnicode_AsEncodedString(pName, "UTF-8", "strict");
   const char * s = PyBytes_AS_STRING(temp_bytes);
-  s = strdup(s);
+  s = _strdup(s);
   Py_DECREF(temp_bytes);
 
   printf("[debug] pName = \"%s\"\n", s);


### PR DESCRIPTION
added implementation of UNIX function gettimeofday, which is only included i77f building on windows.
Replaced static link to Python.h
Fixed empty initialization of float value.
Replaced call to deprecated function