### PR TITLE
Add repository guide and docstrings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,36 @@
+# Repository Guide
+
+This repository contains the **Sibernetic** simulator along with Python
+bindings and tests.  The code base mixes C++ (in `src/` and `inc/`), OpenCL
+kernels and a number of helper Python scripts.
+
+## Layout
+- `src/` – main C++ sources and OpenCL kernels (`sphFluid.cl`).
+- `inc/` – C++ headers with physics constants, solver classes and helpers.
+- `configuration/` – example configuration files for the simulator.
+- `buffers/` – output data (created at runtime).
+- `tests/` – Python tests; `run_all_tests.sh` wraps `sibernetic_c302.py`
+  for automated runs.
+- Python utilities such as `main_sim.py`, `sibernetic_c302.py` and
+  `plot_positions.py` can drive the simulator or analyse its output.
+
+## Building and Testing
+To compile the C++ code use `make`.  A convenience script `test.sh`
+runs code formatting, static checks via **ruff**, builds the simulator
+and executes the test suite:
+
+```bash
+./test.sh
+```
+
+`test.sh` in turn calls `run_all_tests.sh` which performs multiple
+runs of `sibernetic_c302.py` and verifies the produced output files.
+
+## Contributing Notes
+- Keep C++ headers and sources under `inc/` and `src/` respectively.
+- OpenCL kernels reside in `src/*.cl`.
+- When adding Python scripts ensure they pass `ruff format` and
+  `ruff check`.
+- Test additions should be placed under `tests/` and runnable via
+  `test.sh`.
+

--- a/main_sim.py
+++ b/main_sim.py
@@ -1,3 +1,9 @@
+"""
+Utility module used by the C++ simulator to generate
+synthetic muscle activation patterns. Can also be run
+standalone to visualize these waves.
+"""
+
 import math
 import sys
 

--- a/plot_positions.py
+++ b/plot_positions.py
@@ -1,3 +1,9 @@
+"""
+Helper script to visualise particle positions and muscle
+activations logged by the simulator. Used by `sibernetic_c302.py`
+but can be invoked directly.
+"""
+
 import sys
 
 

--- a/sibernetic_c302.py
+++ b/sibernetic_c302.py
@@ -1,3 +1,9 @@
+"""
+Entry point for running the Sibernetic simulator alongside
+c302 neuronal models. Provides command line options for configuring
+duration, device selection and other parameters.
+"""
+
 from pyneuroml import pynml
 import argparse
 import re


### PR DESCRIPTION
## Summary
- document repo structure and build instructions in new `AGENTS.md`
- add module-level docstrings to helper Python scripts

## Testing
- `ruff format main_sim.py plot_positions.py replay.py sibernetic_c302.py`
- `ruff check main_sim.py plot_positions.py replay.py sibernetic_c302.py`
- `make -j2`
- `./run_all_tests.sh` *(fails: File missing due to simulator error)*
- `./test.sh` *(fails at runtime)*


------
https://chatgpt.com/codex/tasks/task_b_686088f73ff8832aa570902edb7789e4