### PR TITLE
Fix solver destructor segfault

### DIFF
--- a/inc/owOpenCLSolver.h
+++ b/inc/owOpenCLSolver.h
@@ -139,7 +139,9 @@ private:
                                const int size);
   void destroy() {
     delete[] gridNextNonEmptyCellBuffer;
+    gridNextNonEmptyCellBuffer = nullptr;
     delete[] _particleIndex;
+    _particleIndex = nullptr;
   }
   // Initialization of openCl data buffers
   void initializeBuffers(const float *, const float *, owConfigProperty *,
@@ -216,8 +218,8 @@ private:
   cl::Kernel computeInteractionWithMembranes_finalize;
 
   // Needed for sorting stuff
-  int *_particleIndex;
-  int *gridNextNonEmptyCellBuffer;
+  int *_particleIndex = nullptr;
+  int *gridNextNonEmptyCellBuffer = nullptr;
 };
 
 #endif // OW_OPENCL_SOLVER_H


### PR DESCRIPTION
## Summary
- initialize `_particleIndex` and `gridNextNonEmptyCellBuffer` pointers to `nullptr`
- reset pointers to `nullptr` inside `owOpenCLSolver::destroy()` to avoid double free or deleting garbage

The change prevents a segmentation fault when constructing `owOpenCLSolver` without valid buffers.

## Testing
- `make`
- `./Release/Sibernetic -no_g -l_to lpath=tests/data/reference_run logstep=50 timelimit=0.00025 timestep=0.000005 -f configuration/test/test_energy`
- `./test.sh` *(fails: File simulations/.../worm_motion_log.txt missing)*

------
https://chatgpt.com/codex/tasks/task_b_6860b94aa2a0832a823a12edc78df5e8