### PR TITLE
Ensure OpenCL runtime and subprocess fallback

### DIFF
--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -2,9 +2,17 @@
 # files produced
 set -ex
 
-# Ensure system site-packages are visible to embedded Python
-export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}/usr/local/lib/python3.12/dist-packages:$(pwd)"
+# Ensure Python can locate packages installed via pip
+PY_SITE=$(python3 - <<'EOF'
+import site, sys
+sys.stdout.write(site.getsitepackages()[0])
+EOF
+)
+export PYTHONPATH="${PYTHONPATH:+$PYTHONPATH:}$PY_SITE:$(pwd)"
 export PATH="/usr/bin:$PATH"
+
+# Warn if pyneuroml is missing; the simulator can fall back to subprocess
+python3 -c "import pyneuroml" 2>/dev/null || echo 'Warning: pyneuroml not found, using subprocess fallback'
 
 # No c302
 python3 sibernetic_c302.py -test -noc302 -duration 0.1

--- a/setup.sh
+++ b/setup.sh
@@ -3,7 +3,16 @@ set -ex
 
 # Install system dependencies for building Sibernetic and the PyTorch solver
 apt-get update
-apt-get install -y python3-dev ocl-icd-opencl-dev libglu1-mesa-dev freeglut3-dev libglew-dev
+apt-get install -y python3-dev ocl-icd-opencl-dev libglu1-mesa-dev freeglut3-dev libglew-dev clinfo pocl-opencl-icd
 
 # Install Python packages
-pip install torch ruff
+pip install torch ruff pyneuroml || echo "Warning: failed to install pyneuroml"
+
+# Verify pyneuroml installed correctly if available
+python3 - <<'EOF'
+try:
+    import pyneuroml
+    print(pyneuroml.__version__)
+except Exception:
+    print('pyneuroml not installed, continuing')
+EOF

--- a/sibernetic_c302.py
+++ b/sibernetic_c302.py
@@ -4,14 +4,15 @@ c302 neuronal models. Provides command line options for configuring
 duration, device selection and other parameters.
 """
 
+import sys
+
 try:
     from pyneuroml import pynml
-except ImportError:  # pyneuroml may not be installed for simple tests
+except ImportError:  # pyneuroml is optional; we can fall back to subprocess
     pynml = None
 import argparse
 import re
 import os
-import sys
 import time
 import math
 
@@ -421,12 +422,25 @@ def run(a=None, **kwargs):
         % (a.duration, command, run_dir, env)
     )
     try:
-        pynml_success = pynml.execute_command_in_dir_with_realtime_output(
-            command, run_dir, prefix="Sibernetic >> ", env=env, verbose=True
-        )
-        completion_status = (
-            SUCCESS if pynml_success else "Failure running command: %s" % command
-        )
+        if pynml is not None:
+            pynml_success = pynml.execute_command_in_dir_with_realtime_output(
+                command, run_dir, prefix="Sibernetic >> ", env=env, verbose=True
+            )
+            completion_status = (
+                SUCCESS if pynml_success else "Failure running command: %s" % command
+            )
+        else:
+            import subprocess
+            import shlex
+
+            res = subprocess.run(
+                shlex.split(command), cwd=run_dir, env=env, capture_output=True
+            )
+            if res.returncode == 0:
+                completion_status = SUCCESS
+            else:
+                sys.stderr.write(res.stderr.decode())
+                completion_status = f"Failure running command: {command}"
     except KeyboardInterrupt:
         print_("\nCaught CTRL+C. Continue...\n")
         completion_status = "Caught CTRL+C"


### PR DESCRIPTION
## Summary
- warn if `pyneuroml` missing rather than aborting tests
- install a CPU OpenCL driver in `setup.sh`
- make `sibernetic_c302.py` fall back to `subprocess` when `pyneuroml` isn't available

## Testing
- `make -j$(nproc)`
- `./run_all_tests.sh`
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_b_686185d49764832a8c117a5c2869496a