### PR TITLE
Add macOS support to setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Install OpenCL on Ubuntu. We suggest you initially go with [AMD OpenCL drivers](
 
 You'll also need a variety of libraries.  A helper script `setup.sh`
 installs all required packages, including OpenCL headers, build tools and
-the Python dependencies:
+the Python dependencies.  The script now detects Linux or macOS and
+uses either `apt` or Homebrew as appropriate:
 
 ```bash
 ./setup.sh

--- a/setup.sh
+++ b/setup.sh
@@ -1,12 +1,21 @@
-#!/bin/bash
-set -ex
+#!/usr/bin/env bash
+set -euo pipefail
 
 # Install system dependencies for building Sibernetic and the PyTorch solver
-apt-get update
-apt-get install -y python3-dev ocl-icd-opencl-dev libglu1-mesa-dev freeglut3-dev libglew-dev clinfo pocl-opencl-icd
+if [[ "$(uname)" == "Darwin" ]]; then
+    if ! command -v brew >/dev/null 2>&1; then
+        echo "Homebrew not found. Please install it from https://brew.sh/" >&2
+        exit 1
+    fi
+    brew update
+    brew install python glew freeglut clinfo opencl-headers || true
+else
+    apt-get update
+    apt-get install -y python3-dev ocl-icd-opencl-dev libglu1-mesa-dev freeglut3-dev libglew-dev clinfo pocl-opencl-icd
+fi
 
 # Install Python packages
-pip install torch ruff pytest pyneuroml || echo "Warning: failed to install pyneuroml"
+python3 -m pip install torch ruff pytest pyneuroml || echo "Warning: failed to install pyneuroml"
 
 # Verify pyneuroml installed correctly if available
 python3 - <<'EOF'


### PR DESCRIPTION
## Summary
- support macOS via Homebrew in `setup.sh`
- document multi-platform setup in README

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_b_6864760cfaf0832ab85fddbe08bfd4ff