### PR TITLE
Disable OpenCL on Apple Silicon

### DIFF
--- a/inc/owPhysicsFluidSimulator.h
+++ b/inc/owPhysicsFluidSimulator.h
@@ -38,8 +38,15 @@
 
 #include "owPhysicsConstant.h"
 #include "owHelper.h"
-#include "owOpenCLSolver.h"
 #include <Python.h>
+
+#if defined(__APPLE__) && defined(__aarch64__)
+#define OW_NO_OPENCL
+#endif
+
+#ifndef OW_NO_OPENCL
+#include "owOpenCLSolver.h"
+#endif
 
 /** owPhysicsFluidSimulator class contains
  *  realization of algorithms.
@@ -67,11 +74,13 @@ class owPhysicsFluidSimulator
 	 *
 	 *  @return velocity_cpp
 	 */
-	float *getVelocity_cpp()
-	{
-		ocl_solver->read_velocity_buffer(velocity_cpp, config);
-		return velocity_cpp;
-	};
+        float *getVelocity_cpp()
+        {
+#ifndef OW_NO_OPENCL
+                ocl_solver->read_velocity_buffer(velocity_cpp, config);
+#endif
+                return velocity_cpp;
+        };
 	/** Getter for density_cpp buffer
 	 *
 	 *  When run this method information about new values of density
@@ -80,11 +89,13 @@ class owPhysicsFluidSimulator
 	 *
 	 *  @return density_cpp
 	 */
-	float *getDensity_cpp()
-	{
-		ocl_solver->read_density_buffer(density_cpp, config);
-		return density_cpp;
-	};
+        float *getDensity_cpp()
+        {
+#ifndef OW_NO_OPENCL
+                ocl_solver->read_density_buffer(density_cpp, config);
+#endif
+                return density_cpp;
+        };
 	/** Getter for particleIndex_cpp buffer
 	 *
 	 *  When run this method information about new values of particleIndex
@@ -93,11 +104,13 @@ class owPhysicsFluidSimulator
 	 *
 	 *  @return particleIndex_cpp
 	 */
-	unsigned int *getParticleIndex_cpp()
-	{
-		ocl_solver->read_particleIndex_buffer(particleIndex_cpp, config);
-		return particleIndex_cpp;
-	};
+        unsigned int *getParticleIndex_cpp()
+        {
+#ifndef OW_NO_OPENCL
+                ocl_solver->read_particleIndex_buffer(particleIndex_cpp, config);
+#endif
+                return particleIndex_cpp;
+        };
 	/** Getter for elasticConnectionsData_cpp buffer
 	 *
 	 *  Method doesn't need to request data from OpenCL device's memory
@@ -136,7 +149,9 @@ class owPhysicsFluidSimulator
 
   private:
     struct timeval simulation_start;
-	owOpenCLSolver *ocl_solver;
+#ifndef OW_NO_OPENCL
+        owOpenCLSolver *ocl_solver;
+#endif
 	PyObject *torchSolver;
 	bool useTorchBackend;
 	float *position_cpp;			   // everywhere in the code %variableName%_cpp means that we create

--- a/makefile
+++ b/makefile
@@ -11,6 +11,12 @@ INCDIR := inc
 BUILDDIR = ./Release
 BINARYDIR = $(BUILDDIR)/obj
 SOURCES = $(wildcard $(SRCDIR)/*.$(SRCEXT))
+
+ARCH := $(shell uname -m)
+ifeq ($(ARCH),arm64)
+SOURCES := $(filter-out $(SRCDIR)/owOpenCLSolver.cpp,$(SOURCES))
+endif
+
 BINARYTESTDIR = $(BINARYDIR)/test
 OBJECTS := $(patsubst $(SRCDIR)/%,$(BINARYDIR)/%,$(SOURCES:.$(SRCEXT)=.o))
 OBJECTS += $(BINARYTESTDIR)/owPhysicTest.o
@@ -20,8 +26,16 @@ PYTHON_CONFIG ?= /usr/bin/python$(PYTHON_VER_MAIN)-config
 
 CPP_DEPS = $(OBJECTS:.o=.d)
 
-LIBS := -lGL -lGLU -lOpenCL -lrt -lglut
-# For python3.8+, you have to include a --embed option
+LIBS := -lGL -lGLU -lrt -lglut
+ifeq ($(ARCH),arm64)
+CXXFLAGS += -DOW_NO_OPENCL
+else
+LIBS += -lOpenCL
+CXXFLAGS += -DCL_TARGET_OPENCL_VERSION=120 # Target OpenCL version is 1.2
+CXXFLAGS += -DCL_HPP_TARGET_OPENCL_VERSION=120 # C++ bindings target OpenCL version 1.2
+CXXFLAGS += -DCL_HPP_MINIMUM_OPENCL_VERSION=120 # Minimum OpenCL version supported is 1.2
+CXXFLAGS += -DCL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY # Enable compatibility for program construction from arrays
+endif
 PYTHON_CONFIG_BASENAME=$(basename $(PYTHON_CONFIG))
 PYTHON_VERSION=$(patsubst python%-config,%,$(PYTHON_CONFIG_BASENAME))
 
@@ -37,10 +51,6 @@ CXXFLAGS += $(shell $(PYTHON_CONFIG) --embed --cflags)
 endif
 
 CXXFLAGS += -fPIE
-CXXFLAGS += -DCL_TARGET_OPENCL_VERSION=120 # Target OpenCL version is 1.2
-CXXFLAGS += -DCL_HPP_TARGET_OPENCL_VERSION=120 # C++ bindings target OpenCL version 1.2
-CXXFLAGS += -DCL_HPP_MINIMUM_OPENCL_VERSION=120 # Minimum OpenCL version supported is 1.2
-CXXFLAGS += -DCL_HPP_ENABLE_PROGRAM_CONSTRUCTION_FROM_ARRAY_COMPATIBILITY # Enable compatibility for program construction from arrays
 EXTRA_LIBS := -L/usr/lib64/OpenCL/vendors/amd/ -L/opt/AMDAPP/lib/x86_64/ -L/usr/lib/x86_64-linux-gnu/
 
 all: CXXFLAGS += -O3

--- a/makefile.OSX
+++ b/makefile.OSX
@@ -6,11 +6,22 @@ SOURCES = src/owSignalSimulator.cpp \
 src/owVtkExport.cpp \
 src/main.cpp \
 src/owHelper.cpp \
-src/owOpenCLSolver.cpp \
 src/owPhysicsFluidSimulator.cpp \
 src/owWorldSimulation.cpp \
 src/owNeuronSimulator.cpp \
 src/owConfigProperty.cpp
+
+ARCH := $(shell uname -m)
+ifeq ($(ARCH),arm64)
+TORCH_FLAGS := -DOW_NO_OPENCL
+OPENCL_FLAG :=
+LIBS := -framework Python -framework OpenGL -framework GLUT
+else
+SOURCES += src/owOpenCLSolver.cpp
+TORCH_FLAGS :=
+OPENCL_FLAG := -framework OpenCL
+LIBS := -framework Python -framework OpenGL -framework GLUT -framework OpenCL
+endif
 
 TEST_SOURCES = src/test/owPhysicTest.cpp
 
@@ -19,6 +30,7 @@ SRCDIR := src
 INCDIR := inc
 BUILDDIR = ./Release
 BINARYDIR = $(BUILDDIR)/obj
+# Change these to set the different python directories
 BINARYTESTDIR = $(BINARYDIR)/test
 OBJECTS := $(patsubst $(SRCDIR)/%,$(BINARYDIR)/%,$(SOURCES:.$(SRCEXT)=.o))
 OBJECTS += $(BINARYTESTDIR)/owPhysicTest.o
@@ -30,9 +42,6 @@ CPP_DEPS = $(OBJECTS:.o=.d)
 # PYTHONLIBDIR = /opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/
 # PYTHONFRAMEWORKDIR = /Library/Frameworks/
 
-LIBS := -framework Python -framework OpenGL -framework GLUT -framework OpenCL
-
-
 # All Target
 all: $(TARGET)
 
@@ -40,7 +49,7 @@ all: $(TARGET)
 $(TARGET): $(OBJECTS)
 	@echo 'Building target: $@'
 	@echo 'Invoking: clang C++ Linker'
-	g++ -std=c++14 -L/usr/lib -F$(PYTHONFRAMEWORKDIR) -L$(PYTHONLIBDIR) -o $(BUILDDIR)/$(TARGET) $(OBJECTS) $(LIBS)
+        g++ -std=c++14 -L/usr/lib -F$(PYTHONFRAMEWORKDIR) -L$(PYTHONLIBDIR) -o $(BUILDDIR)/$(TARGET) $(OBJECTS) $(LIBS)
 	@echo 'Finished building target: $@'
 	@echo ' '
 
@@ -51,7 +60,7 @@ $(BINARYDIR)/%.o: $(SRCDIR)/%.cpp
 	@echo 'Invoking: clang C++ Compiler'
 #### use this to compile against homebrew installed python
 #### change version number as necessary (2.7.n)
-	g++ -std=c++14 -O3 -Wall -c -I$(PYTHONHEADERDIR) -I$(INCDIR) -framework OpenCL -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"
+        g++ -std=c++14 -O3 -Wall $(TORCH_FLAGS) -c -I$(PYTHONHEADERDIR) -I$(INCDIR) $(OPENCL_FLAG) -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' '
 

--- a/makefile_clang
+++ b/makefile_clang
@@ -5,9 +5,18 @@ SOURCES = src/owSignalSimulator.cpp \
 src/owVtkExport.cpp \
 src/main.cpp \
 src/owHelper.cpp \
-src/owOpenCLSolver.cpp \
 src/owPhysicsFluidSimulator.cpp \
 src/owWorldSimulation.cpp
+
+ARCH := $(shell uname -m)
+ifeq ($(ARCH),arm64)
+TORCH_FLAGS := -DOW_NO_OPENCL
+LIBS := -lpython2.7 -lGL -lGLU -lrt -lglut
+else
+SOURCES += src/owOpenCLSolver.cpp
+TORCH_FLAGS :=
+LIBS := -lpython2.7 -lGL -lGLU -lOpenCL -lrt -lglut
+endif
 
 TEST_SOURCES = src/test/owPhysicTest.cpp
 
@@ -24,9 +33,6 @@ COMPILER :=clang++ # select clang as compiler
 
 CPP_DEPS = $(OBJECTS:.o=.d)
 
-LIBS := -lpython2.7 -lGL -lGLU -lOpenCL -lrt -lglut
-
-
 all : $(TARGET)
 
 $(TARGET):$(OBJECTS)
@@ -41,7 +47,7 @@ $(BINARYDIR)/%.o: $(SRCDIR)/%.cpp
 	@mkdir -p $(BINARYTESTDIR)
 	@echo 'Building file: $<'
 	@echo 'Invoking: Clang C++ Compiler'
-	$(COMPILER) -I/usr/include/python2.7 -I$(INCDIR) -O3 -Wall -c  -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<" #-fsanitize=address -g -O0
+        $(COMPILER) -I/usr/include/python2.7 -I$(INCDIR) -O3 -Wall $(TORCH_FLAGS) -c  -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<" #-fsanitize=address -g -O0
 	@echo 'Finished building: $<'
 	@echo ' '
 

--- a/src/owConfigProperty.cpp
+++ b/src/owConfigProperty.cpp
@@ -50,6 +50,9 @@ owConfigProperty::owConfigProperty(int argc, char **argv)
   nrnSimulationFileName = "";
   simulation = nullptr;
   useTorch = false;
+#ifdef OW_NO_OPENCL
+  useTorch = true;
+#endif
     
   fillConstMap(); // map must be filled before parsing arguments, otherwise beta will be NaN because of division by zero
 

--- a/src/owPhysicsFluidSimulator.cpp
+++ b/src/owPhysicsFluidSimulator.cpp
@@ -161,8 +161,12 @@ owPhysicsFluidSimulator::owPhysicsFluidSimulator(owHelper *helper, int argc,
         PyErr_Print();
         throw std::runtime_error("Failed to create PytorchSolver instance");
       }
+#ifndef OW_NO_OPENCL
       ocl_solver = nullptr;
-    } else {
+#endif
+    }
+#ifndef OW_NO_OPENCL
+    else {
       if (config->numOfElasticP != 0) {
         ocl_solver = new owOpenCLSolver(
             position_cpp, velocity_cpp, config, elasticConnectionsData_cpp,
@@ -172,6 +176,7 @@ owPhysicsFluidSimulator::owPhysicsFluidSimulator(owHelper *helper, int argc,
         ocl_solver = new owOpenCLSolver(position_cpp, velocity_cpp,
                                         config); // Create new openCLsolver instance
     }
+#endif
     this->genShellPaticlesList();
   } catch (std::runtime_error &ex) {
     /* Clearing all allocated buffers and created object only not ocl_solver
@@ -276,7 +281,9 @@ void owPhysicsFluidSimulator::reset() {
     Py_DECREF(vel_list);
     Py_DECREF(cfg);
     Py_DECREF(pClass);
-  } else {
+  }
+#ifndef OW_NO_OPENCL
+  else {
     if (config->numOfElasticP != 0) {
       ocl_solver->reset(
           position_cpp, velocity_cpp, config, elasticConnectionsData_cpp,
@@ -286,6 +293,7 @@ void owPhysicsFluidSimulator::reset() {
       ocl_solver->reset(position_cpp, velocity_cpp,
                         config); // Create new openCLsolver instance
   }
+#endif
   this->genShellPaticlesList();
 }
 int update_muscle_activity_signals_log_file(int iterationCount,
@@ -519,6 +527,7 @@ double owPhysicsFluidSimulator::simulationStep(const bool load_to) {
     iterationCount++;
     return helper->getElapsedTime();
   }
+#ifndef OW_NO_OPENCL
   std::cout << "\n[[ Step " << iterationCount << " (total steps: ";
   if (config->getNumberOfIterations() == 0)
     std::cout << "unlimited";
@@ -676,6 +685,10 @@ double owPhysicsFluidSimulator::simulationStep(const bool load_to) {
   ocl_solver->updateMuscleActivityData(muscle_activation_signal_cpp, config);
   iterationCount++;
   return helper->getElapsedTime();
+#else
+  (void)load_to;
+  throw std::runtime_error("OpenCL backend disabled");
+#endif
 }
 /** Prepare data and log it to special configuration
  *  file you can run your simulation from place you snapshoted it
@@ -695,8 +708,10 @@ void owPhysicsFluidSimulator::makeSnapshot() {
 owPhysicsFluidSimulator::~owPhysicsFluidSimulator(void) {
   destroy();
   delete config;
+#ifndef OW_NO_OPENCL
   if (ocl_solver)
     delete ocl_solver;
+#endif
   if (torchSolver) {
     Py_DECREF(torchSolver);
     Py_Finalize();


### PR DESCRIPTION
## Summary
- Disable OpenCL build on Apple Silicon and default to PyTorch backend
- Guard OpenCL-specific code with `OW_NO_OPENCL`
- Update makefiles to skip OpenCL sources and libraries on arm64

## Testing
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_b_6895f0984cbc832ab354ad98c612c423