### PR TITLE
upgrade opencl target version to 300 from 120

### DIFF
--- a/.github/workflows/ci-build-intel.yml
+++ b/.github/workflows/ci-build-intel.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ ubuntu-22.04, ubuntu-24.04 ]
+        runs-on: [ ubuntu-24.04, ubuntu-26.04 ]
 
     steps:
     - name: Set git to use LF
@@ -31,24 +31,18 @@ jobs:
 
         echo "Installing OpenCL Drivers"
 
-        # Based on: https://github.com/openworm/OpenWorm/blob/master/Dockerfile
-
-        mkdir intel-opencl-tmp
-        cd intel-opencl-tmp
-        mkdir intel-opencl
-        wget https://github.com/openworm/OpenWorm/raw/dev_inte/SRB5.0_linux64.zip
-        unzip SRB5.0_linux64.zip
-        tar -C intel-opencl -Jxf intel-opencl-r5.0-63503.x86_64.tar.xz
-        tar -C intel-opencl -Jxf intel-opencl-devel-r5.0-63503.x86_64.tar.xz
-        tar -C intel-opencl -Jxf intel-opencl-cpu-r5.0-63503.x86_64.tar.xz
-        sudo cp -R intel-opencl/* /
-        sudo ldconfig
-        cd ..
-        sudo rm -r intel-opencl-tmp
-
-        sudo cp -R /opt/intel/opencl/include/CL /usr/include/
-        sudo apt-get update --fix-missing 
-        sudo apt install -y ocl-icd-opencl-dev vim
+        sudo apt-get update
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+              build-essential \
+              ocl-icd-libopencl1 \
+              ocl-icd-opencl-dev \
+              opencl-clhpp-headers \
+              pocl-opencl-icd \
+              mesa-opencl-icd \
+              clinfo \
+              python3-dev \
+              freeglut3-dev \
+              libglu1-mesa-dev
 
         echo "OpenCL Driver Installation Complete"
 
@@ -56,8 +50,6 @@ jobs:
     - name: Build Sibernetic
       run: |
 
-        sudo apt install -y python3-dev freeglut3-dev libglu1-mesa-dev
-        #sudo apt install -y  --allow-downgrades libc-bin=2.27-3ubuntu1.5 # Fails with 2.27-3ubuntu1.6 for some reason...
         python -V
         ls -alt /usr/bin/python*
         ls -alt
@@ -72,8 +64,7 @@ jobs:
       run: |
         ldd ./Release/Sibernetic
 
-        echo "NOTE: not running Sibernetic on GitHub actions test with Intel drivers. Seg faults."
-        ###./Release/Sibernetic -no_g timelimit=0.001
+        ./Release/Sibernetic -no_g timelimit=0.001
 
     - name: Final version info
       run: |

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ ubuntu-22.04, ubuntu-24.04 ]
+        runs-on: [ ubuntu-24.04, ubuntu-26.04 ]
 
     steps:
     - name: Set git to use LF
@@ -29,35 +29,22 @@ jobs:
 
         lscpu
 
-        echo "Installing OpenCL Drivers"
+        echo "Installing OpenCL Drivers and Java(for jNeuroML)"
 
-        # Legacy install of Intel's OpenCL Drivers:
-        # Based on: https://github.com/openworm/OpenWorm/blob/master/Dockerfile
-        # mkdir intel-opencl-tmp
-        # cd intel-opencl-tmp
-        # mkdir intel-opencl
-        # wget https://github.com/openworm/OpenWorm/raw/dev_inte/SRB5.0_linux64.zip
-        # unzip SRB5.0_linux64.zip
-        # tar -C intel-opencl -Jxf intel-opencl-r5.0-63503.x86_64.tar.xz
-        # tar -C intel-opencl -Jxf intel-opencl-devel-r5.0-63503.x86_64.tar.xz
-        # tar -C intel-opencl -Jxf intel-opencl-cpu-r5.0-63503.x86_64.tar.xz
-        # sudo cp -R intel-opencl/* /
-        # sudo ldconfig
-        # cd ..
-        # sudo rm -r intel-opencl-tmp
-
-        # sudo cp -R /opt/intel/opencl/include/CL /usr/include/
-        # sudo apt install -y ocl-icd-opencl-dev vim 
-
-        # Install AMD's OpenCL Drivers (AMD-APP-SDK 3.0):
-        wget https://master.dl.sourceforge.net/project/nicehashsgminerv5viptools/APP%20SDK%20A%20Complete%20Development%20Platform/AMD%20APP%20SDK%203.0%20for%2064-bit%20Linux/AMD-APP-SDKInstaller-v3.0.130.136-GA-linux64.tar.bz2
-        tar -xf AMD-APP-SDKInstaller-v3.0.130.136-GA-linux64.tar.bz2
-        printf 'Y\n\n' | sudo ./AMD-APP-SDK-v3.0.130.136-GA-linux64.sh
-        
-        sudo ln -s /opt/AMDAPPSDK-3.0/lib/x86_64/sdk/libOpenCL.so.1 /usr/lib/libOpenCL.so.1
-        sudo ln -s /opt/AMDAPPSDK-3.0/lib/x86_64/sdk/libamdocl64.so /usr/lib/libamdocl64.so
-
-        sudo apt install -y ocl-icd-opencl-dev
+        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+          build-essential \
+          git \
+          python3-dev \
+          default-jre-headless \
+          libopengl0 \
+          freeglut3-dev \
+          libglu1-mesa-dev \
+          clinfo \
+          ocl-icd-libopencl1 \
+          ocl-icd-opencl-dev \
+          opencl-clhpp-headers \
+          pocl-opencl-icd \
+          mesa-opencl-icd
 
         echo "OpenCL Driver Installation Complete"
 
@@ -67,8 +54,6 @@ jobs:
     - name: Build Sibernetic
       run: |
 
-        sudo apt install -y python3-dev freeglut3-dev libglu1-mesa-dev
-        #sudo apt install -y  --allow-downgrades libc-bin=2.27-3ubuntu1.5 # Fails with 2.27-3ubuntu1.6 for some reason...
         python -V
         ls -alt /usr/bin/python*
         ls -alt

--- a/inc/owOpenCLSolver.h
+++ b/inc/owOpenCLSolver.h
@@ -31,8 +31,6 @@
  * USE OR OTHER DEALINGS IN THE SOFTWARE.
  *******************************************************************************/
 
-#define CL_TARGET_OPENCL_VERSION 120
-
 #ifndef OW_OPENCL_SOLVER_H
 #define OW_OPENCL_SOLVER_H
 
@@ -44,7 +42,7 @@
 #include "../inc/OpenCL/cl.hpp"
 //	#include <OpenCL/cl_d3d10.h>
 #else
-#include <CL/cl.hpp>
+#include <CL/opencl.hpp>
 #endif
 
 #include "owConfigProperty.h"

--- a/makefile
+++ b/makefile
@@ -36,7 +36,7 @@ LIBS += $(shell $(PYTHON_CONFIG) --embed --libs)
 CXXFLAGS += $(shell $(PYTHON_CONFIG) --embed --cflags)
 endif
 
-CXXFLAGS += -fPIE
+CXXFLAGS += -fPIE -DCL_TARGET_OPENCL_VERSION=300 -DCL_HPP_TARGET_OPENCL_VERSION=300 -DCL_HPP_MINIMUM_OPENCL_VERSION=300
 EXTRA_LIBS := -L/usr/lib64/OpenCL/vendors/amd/ -L/opt/AMDAPP/lib/x86_64/ -L/usr/lib/x86_64-linux-gnu/
 
 all: CXXFLAGS += -O3
@@ -58,7 +58,7 @@ $(BINARYDIR)/%.o: $(SRCDIR)/%.cpp
 	@mkdir -p $(BINARYTESTDIR)
 	@echo 'Building file: $<'
 	@echo 'Invoking: GCC C++ Compiler'
-	$(CC) $(CXXFLAGS) -I/opt/AMDAPPSDK-3.0/include/ -I/opt/AMDAPP/include/ -I$(INCDIR) -Wall -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"
+	$(CC) $(CXXFLAGS) -I$(INCDIR) -Wall -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' '
 

--- a/sibernetic_c302.py
+++ b/sibernetic_c302.py
@@ -439,6 +439,9 @@ def run(a=None, **kwargs):
         "PYTHONPATH": ".:%s:%s"
         % (os.environ.get("PYTHONPATH", "."), os.path.abspath(sim_dir)),
         "NEURON_MODULE_OPTIONS": "-nogui",
+        "PATH": os.environ.get("PATH")
+        if os.environ.get("PATH") is not None
+        else "",
     }
 
     sim_start = time.time()

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,8 +31,6 @@
  * USE OR OTHER DEALINGS IN THE SOFTWARE.
  *******************************************************************************/
 
-#define CL_TARGET_OPENCL_VERSION 120
-
 #include "owPhysicTest.h"
 #include "owVtkExport.h"
 #include "owWorldSimulation.h"

--- a/src/owOpenCLSolver.cpp
+++ b/src/owOpenCLSolver.cpp
@@ -409,8 +409,8 @@ void owOpenCLSolver::initializeOpenCL(owConfigProperty *config) {
   }
   std::string programSource(std::istreambuf_iterator<char>(file),
                             (std::istreambuf_iterator<char>()));
-  cl::Program::Sources source(
-      1, std::make_pair(programSource.c_str(), programSource.length() + 1));
+  cl::Program::Sources source;
+  source.push_back(programSource);
   program = cl::Program(context, source);
 #if defined(__APPLE__)
   err = program.build(devices, "-g -cl-opt-disable");


### PR DESCRIPTION
This PR should ideally target development branch but it's 204 commits behind ow-0.9.9 so sending to it instead. Hopefully this can be merged into ow-0.9.10

Changes
1. update macros and minor code changes to handle opencl version updates
2. start passing `PATH` env variable cause otherwise sibernetic in cpu config is failing to run due to not finding `ld`

all github workflow based tests pass