### PR TITLE
Make Taichi backend reproducible without PYTHONPATH or a hidden venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ simulations
 .vscode/*
 .settings/*
 .idea/*
+
+# Project-local Python venv created by setup.sh
+/.venv/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Sibernetic is physical simulator of biomechanical matter (membranes, elastic matter, contractile matter) and environments (liquids, solids and elastic matter with variable physical properties) developed for simulations of C. elegans physical body dynamics within the [OpenWorm project](http://www.openworm.org) by Andrey Palyanov, Sergey Khayrulin and Mike Vella (development of a Python module for external muscle activating signals generation and input) as part of the [OpenWorm team](http://www.openworm.org/people.html). At its core, Sibernetic is built as an extension to Predictive-Corrective Incompressible Smoothed Particle Hydrodynamics (PCISPH). It is primarily written in  C++ and OpenCL, which makes possible to run simulations on CPUs or GPUs, and has 3D visualization support built on top of OpenGL.
 
-This repository also ships a simplified solver written in PyTorch (`pytorch_solver.py`) which is used in the unit tests.
+This repository also ships simplified solvers written in PyTorch (`pytorch_solver.py`) and Taichi (`taichi_solver.py`). The PyTorch solver is used in the unit tests; the Taichi solver provides GPU-accelerated simulation on Apple Silicon (Metal) and NVIDIA GPUs (CUDA).
 
 There is a separate effort lead by [Giovanni Idili](https://github.com/gidili) and [Sergey Khayrulin](https://github.com/skhayrulin) to port this code to Java, as part of the [Geppetto simulation framework](http://www.geppetto.org/).
 
@@ -45,7 +45,15 @@ ldconfig -p | grep opencl
 
 Also you may need to give compiler path to OpenCL header files usually you can find them in `/usr/include/CL` if they there than you don't need do anything. In othe case you can edit makefile directly and add directory to OpenCL headers by adding options `-I/path/to/opencl_includes/` or you can copy folder with header into `/usr/include/` but you should have root permission for doing that.
 
-**Mac**: stay in the top-level folder. You need before run export several environment variables:
+**Mac**: stay in the top-level folder. The recommended path is just:
+
+```bash
+./setup.sh
+```
+
+This installs Homebrew dependencies, creates a project-local `.venv/` with `torch`, `taichi`, `numpy`, and `pyneuroml`, exports the build-time Python paths, and runs `make -f makefile.OSX` for you.
+
+If you prefer to drive `make` yourself, you'll need to export the build-time Python paths first:
 
 ```bash
 export PYTHONHEADERDIR=/opt/homebrew/Frameworks/Python.framework/Headers/
@@ -76,11 +84,7 @@ g++ -L/usr/lib -L/usr/lib/python2.7 -o "Sibernetic"  ./src/PyramidalSimulation.o
 Finished building target:Sibernetic
 ```
 
-Then navigate to the top-level folder in the hierarchy (e.g `Sibernetic`) and set your `PYTHONPATH`:
-
-```bash
-export PYTHONPATH=$PYTHONPATH:.
-```
+Then run from the top-level folder (e.g `Sibernetic`). The binary adds the repo root and `./.venv/lib/python*/site-packages` to `sys.path` automatically — you do not need to set `PYTHONPATH` for the PyTorch or Taichi backends. (The legacy NEURON/c302 bridge in `owSignalSimulator.cpp` and `owNeuronSimulator.cpp` still relies on `PYTHONPATH`; export it only if you're running neural-coupled simulations.)
 
 Finally, to run, run the command:
 
@@ -170,12 +174,14 @@ Sibernetic supports multiple compute backends:
 | Taichi CPU | `backend=taichi-cpu` | CPU fallback |
 | PyTorch | `backend=torch` | Quick tests, debugging |
 
-**Apple Silicon (M1/M2/M3)**: Use Taichi for best performance (~100x faster than CPU):
-```bash
-# Set Python paths (add to .zshrc for convenience)
-export PYTHONPATH=$(pwd):$(.venv/bin/python -c "import site; print(site.getsitepackages()[0])")
+### Installing the Python dependencies
 
-# Run with Metal GPU
+`./setup.sh` installs the Taichi and PyTorch runtime libraries into a project-local `.venv/` (on macOS — Linux uses system pip). The C++ binary automatically adds `.venv/lib/python*/site-packages` and the repo root to `sys.path` at startup, so **you do not need to export `PYTHONPATH`**. Just run the binary from the repo root.
+
+If you ever recreate the venv by hand, make sure it lives at `<repo-root>/.venv/` so the binary can find it.
+
+**Apple Silicon (M1/M2/M3)** — Taichi Metal is the fastest backend (~100x faster than CPU):
+```bash
 ./Release/Sibernetic -f worm backend=taichi
 ```
 
@@ -188,8 +194,6 @@ export PYTHONPATH=$(pwd):$(.venv/bin/python -c "import site; print(site.getsitep
 ```bash
 ./Release/Sibernetic -no_g -f demo1 backend=torch timelimit=0.01
 ```
-
-The Taichi and PyTorch backends require Python dependencies from `setup.sh`.
 
 Python Solver Development Status
 --------------------------------

--- a/setup.sh
+++ b/setup.sh
@@ -13,8 +13,20 @@ if [[ "$(uname)" == "Darwin" ]]; then
     brew update
     brew install python glew freeglut clinfo opencl-headers pipx || true
 
-    # Install Python packages
-    pipx install torch ruff pytest pyneuroml || echo "Warning: failed to install pyneuroml"
+    # CLI tools (run as commands, not imported) — pipx-isolated venvs are fine
+    pipx install ruff || true
+    pipx install pytest || true
+
+    # Runtime libraries embedded by the C++ binary must be importable from the
+    # same Python that Sibernetic links against. pipx isolates each package in
+    # its own venv, which makes them invisible to the embedded interpreter, so
+    # use a project-local venv on top of Homebrew's python3 instead.
+    if [[ ! -d .venv ]]; then
+        python3 -m venv .venv
+    fi
+    .venv/bin/pip install --upgrade pip
+    .venv/bin/pip install torch taichi numpy pyneuroml || \
+        echo "Warning: failed to install one or more runtime Python packages"
 
     export PYTHONHEADERDIR="$(python3 -c 'import sysconfig; print(sysconfig.get_path("include"))')"
     export PYTHONLIBDIR=$(python3 -c 'import sysconfig; print(sysconfig.get_config_var("LIBDIR"))')
@@ -23,12 +35,16 @@ if [[ "$(uname)" == "Darwin" ]]; then
     make clean -f makefile.OSX
     make all -f makefile.OSX
 
+    echo
+    echo "Build complete. Run from the repo root, e.g.:"
+    echo "  ./Release/Sibernetic -f worm backend=taichi"
+
 else
     apt-get update
     apt-get install -y python3-dev ocl-icd-opencl-dev libglu1-mesa-dev freeglut3-dev libglew-dev clinfo pocl-opencl-icd
 
     # Install Python packages
-    python3 -m pip install torch ruff pytest pyneuroml || echo "Warning: failed to install pyneuroml"
+    python3 -m pip install torch taichi ruff pytest pyneuroml || echo "Warning: failed to install pyneuroml"
 
 fi
 

--- a/src/owPhysicsFluidSimulator.cpp
+++ b/src/owPhysicsFluidSimulator.cpp
@@ -46,6 +46,22 @@
 #include "owSignalSimulator.h"
 #include "owVtkExport.h"
 
+// Make pytorch_solver.py / taichi_solver.py and packages installed in the
+// project-local .venv importable from the embedded interpreter without the
+// user having to export PYTHONPATH first. Assumes the binary is launched from
+// the repo root, which matches the existing OpenCL kernel-path convention.
+static void setupEmbeddedPythonPath() {
+  PyRun_SimpleString(
+      "import sys, os, glob\n"
+      "_cwd = os.getcwd()\n"
+      "if _cwd not in sys.path:\n"
+      "    sys.path.insert(0, _cwd)\n"
+      "for _p in glob.glob(os.path.join(_cwd, '.venv', 'lib', 'python*', 'site-packages')):\n"
+      "    if _p not in sys.path:\n"
+      "        sys.path.append(_p)\n"
+  );
+}
+
 // Phase 1.4: Helper to eliminate duplicate init code between constructor and reset()
 void owPhysicsFluidSimulator::initTorchSolver(bool isReset) {
   // Clean up existing solver if this is a reset
@@ -352,6 +368,7 @@ owPhysicsFluidSimulator::owPhysicsFluidSimulator(owHelper *helper, int argc,
 
     if (useTorchBackend) {
       Py_Initialize();
+      setupEmbeddedPythonPath();  // Add cwd + .venv site-packages to sys.path
       _import_array();  // Initialize NumPy C API for fast array access (no return)
       initTorchSolver(false);  // Phase 1.4: Use helper (not a reset)
 #ifndef OW_NO_OPENCL
@@ -359,6 +376,7 @@ owPhysicsFluidSimulator::owPhysicsFluidSimulator(owHelper *helper, int argc,
 #endif
     } else if (useTaichiBackend) {
       Py_Initialize();
+      setupEmbeddedPythonPath();  // Add cwd + .venv site-packages to sys.path
       _import_array();  // Initialize NumPy C API for fast array access (no return)
       initTaichiSolver(false);  // Initialize Taichi GPU solver
 #ifndef OW_NO_OPENCL


### PR DESCRIPTION
Background: a collaborator hit "Python.h not found" and ModuleNotFoundError for taichi after a fresh checkout. setup.sh installed torch via pipx (which isolates it from the embedded interpreter) and never installed taichi at all — the local Taichi backend only worked because of an undeclared .venv on the maintainer's machine.

- setup.sh (macOS): create a project-local .venv on top of Homebrew python3 and install torch, taichi, numpy, and pyneuroml into it. Keep ruff and pytest in pipx since they are CLI tools.
- setup.sh (Linux): add taichi to the system pip install.
- owPhysicsFluidSimulator.cpp: after Py_Initialize() in the torch and taichi init paths, inject the cwd and any <cwd>/.venv/lib/python*/site-packages into sys.path so the embedded interpreter can import the solver modules and their dependencies without the user setting PYTHONPATH.
- README: recommend ./setup.sh as the primary path on macOS, drop the obsolete PYTHONPATH export, and document that the binary now self-locates the venv. Mention that owSignalSimulator.cpp / owNeuronSimulator.cpp still rely on PYTHONPATH for the NEURON/c302 bridge.
- .gitignore: ignore /.venv/ at the project root.